### PR TITLE
Fix both dozer icons from being hidden

### DIFF
--- a/Dozer/AppDelegate.swift
+++ b/Dozer/AppDelegate.swift
@@ -18,7 +18,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             Fabric.with([Crashlytics.self])
         #endif
 
-        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: UserDefaultKeys.Shortcuts.ToggleMenuItems) { [unowned self] in
+        MASShortcutBinder.shared()?.bindShortcut(withDefaultsKey: UserDefaultKeys.Shortcuts.ToggleMenuItems) { () in
             DozerIcons.shared.toggle()
         }
 

--- a/Dozer/DozerIcons.swift
+++ b/Dozer/DozerIcons.swift
@@ -68,6 +68,7 @@ public final class DozerIcons {
                 let rightDozerIconXPos = get(dozerIcon: .normalRight).xPositionOnScreen
                 dozerIcons.removeAll(where: { $0.xPositionOnScreen == rightDozerIconXPos })
             } else {
+                show()
                 dozerIcons.append(NormalStatusIcon())
             }
         }


### PR DESCRIPTION
Noticed a bug when creating contributions. The bug, if hide both Dozer icons is enabled, the dozer icon is hidden, and the user unchecks hide both Dozer icons, then both dozer icons would be hidden and using the command to show/hide the icons wouldn't work. Forcing the icons to show when turning off hide both Dozer icons resolves the issue.