### PR TITLE
Introduce interaction timer on opt-click

### DIFF
--- a/Dozer/DozerIcons.swift
+++ b/Dozer/DozerIcons.swift
@@ -212,6 +212,8 @@ public final class DozerIcons {
                 statusIcon: .remove
             )
         }
+        stopUserInteractionTimer()
+        startUserInteractionTimer()
         resetTimer()
     }
 


### PR DESCRIPTION
Previously there was no user-interaction timer on the opt-click function.

- Opening Dozer immediately using opt-click makes the lack of interaction timer clear.

- Opening Dozer first with regular click, and then later expanding visible icons using opt-click masks the lack of interaction timer.

Fixes #127 

ps: I have a personal, uncommitted branch with a ton of debugging statements in it which has let me find this sort of edge case bug and others like it. Do we want debug statements in the main repo?