### PR TITLE
brew cask is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 <a href="https://www.buymeacoffee.com/mortennn" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 
 ## ⚙️ Install
-Using [Homebrew Cask](https://formulae.brew.sh/cask/dozer/):
+Using [Homebrew Cask](https://formulae.brew.sh/cask/dozer):
 ```shell
 brew install --cask dozer
 ```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 <a href="https://www.buymeacoffee.com/mortennn" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 
 ## ⚙️ Install
-Using [Homebrew Cask](https://caskroom.github.io/):
+Using [Homebrew Cask](https://formulae.brew.sh/cask/dozer/):
 ```shell
-brew cask install dozer
+brew install --cask dozer
 ```
 
 Manual:


### PR DESCRIPTION
Running `brew cask install dozer` triggers a warning:
`Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.`

I updated the readme.

Thanks for the awesome tool 👍