### PR TITLE
Update README to suggest new brew cask syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## ⚙️ Install
 Using [Homebrew Cask](https://caskroom.github.io/):
 ```shell
-brew cask install dozer
+brew install --cask dozer
 ```
 
 Manual:


### PR DESCRIPTION
Homebrew updated the cask installation syntax recently, so this change suggests the new syntax. Information about the change can be found here: https://brew.sh/2020/12/01/homebrew-2.6.0/

`brew install dozer` also works, but this will guarantee that the user gets this cask just in case someone adds a dozer formulae