### PR TITLE
update install command to use brew install --cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## ⚙️ Install
 Using [Homebrew Cask](https://caskroom.github.io/):
 ```shell
-brew cask install dozer
+brew install --cask dozer
 ```
 
 Manual:


### PR DESCRIPTION
Got this error when using the currently suggested command:
```
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```