### PR TITLE
updated brew install command to reflect --cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ## ⚙️ Install
 Using [Homebrew Cask](https://caskroom.github.io/):
 ```shell
-brew cask install dozer
+brew install --cask dozer
 ```
 
 Manual:


### PR DESCRIPTION
Received an error installing via HomeBrew

Error: Calling brew cask install is disabled! Use brew install [--cask] instead.

This is expected behavior. brew cask <command> was deprecated in favor of brew <command> --cask in Homebrew 2.6.0. Now that 2.7.0 has been released, they have been disabled. This was documented in the release notes and on the Homebrew blog in addition to the messages at the command-line

new command should be : 

brew install --cask dozer